### PR TITLE
Shorten module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ playbook `ciscosmb_gather_facts.yml`
     # Collect data
     #
     - name: CiscoSMB - Gather Facts - subset default
-      communtity.ciscosmb.ciscosmb_facts:
+      communtity.ciscosmb.facts:
         gather_subset:
           - default
       # when: ansible_network_os == 'community.ciscosmb.ciscosmb'
 
     - name: CiscoSMB - Gather Facts - subset config
-      community.ciscosmb.ciscosmb_facts:
+      community.ciscosmb.facts:
         gather_subset:
           - config
       # when: ansible_network_os == 'community.ciscosmb.ciscosmb'

--- a/changelogs/fragments/CI.yaml
+++ b/changelogs/fragments/CI.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - setup standard Ansible CI

--- a/changelogs/fragments/shorten_module_name.yaml
+++ b/changelogs/fragments/shorten_module_name.yaml
@@ -1,0 +1,3 @@
+major_changes:
+  - transform community.ciscosmb.ciscosmb_command to community.ciscosmb.command
+  - transform community.ciscosmb.ciscosmb_facts to community.ciscosmb.facts

--- a/plugins/modules/command.py
+++ b/plugins/modules/command.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 ---
-module: ciscosmb_command
+module: command
 author: "Petr Klima (@qaxi)"
 short_description: Run commands on remote Cisco SMB devices
 description:

--- a/plugins/modules/facts.py
+++ b/plugins/modules/facts.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 DOCUMENTATION = """
 ---
-module: ciscosmb_facts
+module: facts
 author: "Petr Klima (@qaxi)"
 short_description: Collect facts from remote devices running Cisco SMB
 description:
@@ -35,16 +35,16 @@ options:
 
 EXAMPLES = """
 - name: Collect all facts from the device
-  community.ciscosmb.ciscosmb_facts:
+  community.ciscosmb.facts:
     gather_subset: all
 
 - name: Collect only the config and default facts
-  community.ciscosmb.ciscosmb_facts:
+  community.ciscosmb.facts:
     gather_subset:
       - config
 
 - name: Do not collect hardware facts
-  community.ciscosmb.ciscosmb_facts:
+  community.ciscosmb.facts:
     gather_subset:
       - "!hardware"
 """

--- a/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_command-CBS350-24P-4G.py
+++ b/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_command-CBS350-24P-4G.py
@@ -21,16 +21,16 @@ from ansible_collections.community.ciscosmb.tests.unit.compat.mock import patch
 from ansible_collections.community.ciscosmb.tests.unit.plugins.modules.utils import set_module_args
 from .ciscosmb_module import TestCiscoSMBModule, load_fixture
 
-from ansible_collections.community.ciscosmb.plugins.modules import ciscosmb_command
+from ansible_collections.community.ciscosmb.plugins.modules import command
 
 
 class TestCiscoSMBFactsModule(TestCiscoSMBModule):
 
-    module = ciscosmb_command
+    module = command
 
     def setUp(self):
         super(TestCiscoSMBFactsModule, self).setUp()
-        self.mock_run_commands = patch('ansible_collections.community.ciscosmb.plugins.modules.ciscosmb_command.run_commands')
+        self.mock_run_commands = patch('ansible_collections.community.ciscosmb.plugins.modules.command.run_commands')
         self.run_commands = self.mock_run_commands.start()
 
     def tearDown(self):

--- a/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_command-SG350-28-K9.py
+++ b/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_command-SG350-28-K9.py
@@ -21,16 +21,16 @@ from ansible_collections.community.ciscosmb.tests.unit.compat.mock import patch
 from ansible_collections.community.ciscosmb.tests.unit.plugins.modules.utils import set_module_args
 from .ciscosmb_module import TestCiscoSMBModule, load_fixture
 
-from ansible_collections.community.ciscosmb.plugins.modules import ciscosmb_command
+from ansible_collections.community.ciscosmb.plugins.modules import command
 
 
 class TestCiscoSMBFactsModule(TestCiscoSMBModule):
 
-    module = ciscosmb_command
+    module = command
 
     def setUp(self):
         super(TestCiscoSMBFactsModule, self).setUp()
-        self.mock_run_commands = patch('ansible_collections.community.ciscosmb.plugins.modules.ciscosmb_command.run_commands')
+        self.mock_run_commands = patch('ansible_collections.community.ciscosmb.plugins.modules.command.run_commands')
         self.run_commands = self.mock_run_commands.start()
 
     def tearDown(self):

--- a/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_command-SG500-52-K9.py
+++ b/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_command-SG500-52-K9.py
@@ -21,16 +21,16 @@ from ansible_collections.community.ciscosmb.tests.unit.compat.mock import patch
 from ansible_collections.community.ciscosmb.tests.unit.plugins.modules.utils import set_module_args
 from .ciscosmb_module import TestCiscoSMBModule, load_fixture
 
-from ansible_collections.community.ciscosmb.plugins.modules import ciscosmb_command
+from ansible_collections.community.ciscosmb.plugins.modules import command
 
 
 class TestCiscoSMBFactsModule(TestCiscoSMBModule):
 
-    module = ciscosmb_command
+    module = command
 
     def setUp(self):
         super(TestCiscoSMBFactsModule, self).setUp()
-        self.mock_run_commands = patch('ansible_collections.community.ciscosmb.plugins.modules.ciscosmb_command.run_commands')
+        self.mock_run_commands = patch('ansible_collections.community.ciscosmb.plugins.modules.command.run_commands')
         self.run_commands = self.mock_run_commands.start()
 
     def tearDown(self):

--- a/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_command-SG550X-24MP-K9.py
+++ b/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_command-SG550X-24MP-K9.py
@@ -21,16 +21,16 @@ from ansible_collections.community.ciscosmb.tests.unit.compat.mock import patch
 from ansible_collections.community.ciscosmb.tests.unit.plugins.modules.utils import set_module_args
 from .ciscosmb_module import TestCiscoSMBModule, load_fixture
 
-from ansible_collections.community.ciscosmb.plugins.modules import ciscosmb_command
+from ansible_collections.community.ciscosmb.plugins.modules import command
 
 
 class TestCiscoSMBFactsModule(TestCiscoSMBModule):
 
-    module = ciscosmb_command
+    module = command
 
     def setUp(self):
         super(TestCiscoSMBFactsModule, self).setUp()
-        self.mock_run_commands = patch('ansible_collections.community.ciscosmb.plugins.modules.ciscosmb_command.run_commands')
+        self.mock_run_commands = patch('ansible_collections.community.ciscosmb.plugins.modules.command.run_commands')
         self.run_commands = self.mock_run_commands.start()
 
     def tearDown(self):

--- a/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_command-stackSG550X-48.py
+++ b/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_command-stackSG550X-48.py
@@ -21,16 +21,16 @@ from ansible_collections.community.ciscosmb.tests.unit.compat.mock import patch
 from ansible_collections.community.ciscosmb.tests.unit.plugins.modules.utils import set_module_args
 from .ciscosmb_module import TestCiscoSMBModule, load_fixture
 
-from ansible_collections.community.ciscosmb.plugins.modules import ciscosmb_command
+from ansible_collections.community.ciscosmb.plugins.modules import command
 
 
 class TestCiscoSMBFactsModule(TestCiscoSMBModule):
 
-    module = ciscosmb_command
+    module = command
 
     def setUp(self):
         super(TestCiscoSMBFactsModule, self).setUp()
-        self.mock_run_commands = patch('ansible_collections.community.ciscosmb.plugins.modules.ciscosmb_command.run_commands')
+        self.mock_run_commands = patch('ansible_collections.community.ciscosmb.plugins.modules.command.run_commands')
         self.run_commands = self.mock_run_commands.start()
 
     def tearDown(self):

--- a/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_facts-CBS350-24P-4G.py
+++ b/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_facts-CBS350-24P-4G.py
@@ -18,18 +18,18 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible_collections.community.ciscosmb.tests.unit.compat.mock import patch
-from ansible_collections.community.ciscosmb.plugins.modules import ciscosmb_facts
+from ansible_collections.community.ciscosmb.plugins.modules import facts
 from ansible_collections.community.ciscosmb.tests.unit.plugins.modules.utils import set_module_args
 from .ciscosmb_module import TestCiscoSMBModule, load_fixture
 
 
 class TestCiscoSMBFactsModule(TestCiscoSMBModule):
 
-    module = ciscosmb_facts
+    module = facts
 
     def setUp(self):
         super(TestCiscoSMBFactsModule, self).setUp()
-        self.mock_run_commands = patch('ansible_collections.community.ciscosmb.plugins.modules.ciscosmb_facts.run_commands')
+        self.mock_run_commands = patch('ansible_collections.community.ciscosmb.plugins.modules.facts.run_commands')
         self.run_commands = self.mock_run_commands.start()
 
     def tearDown(self):

--- a/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_facts-SG350-28-K9.py
+++ b/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_facts-SG350-28-K9.py
@@ -18,18 +18,18 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible_collections.community.ciscosmb.tests.unit.compat.mock import patch
-from ansible_collections.community.ciscosmb.plugins.modules import ciscosmb_facts
+from ansible_collections.community.ciscosmb.plugins.modules import facts
 from ansible_collections.community.ciscosmb.tests.unit.plugins.modules.utils import set_module_args
 from .ciscosmb_module import TestCiscoSMBModule, load_fixture
 
 
 class TestCiscoSMBFactsModule(TestCiscoSMBModule):
 
-    module = ciscosmb_facts
+    module = facts
 
     def setUp(self):
         super(TestCiscoSMBFactsModule, self).setUp()
-        self.mock_run_commands = patch('ansible_collections.community.ciscosmb.plugins.modules.ciscosmb_facts.run_commands')
+        self.mock_run_commands = patch('ansible_collections.community.ciscosmb.plugins.modules.facts.run_commands')
         self.run_commands = self.mock_run_commands.start()
 
     def tearDown(self):

--- a/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_facts-SG500-52-K9.py
+++ b/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_facts-SG500-52-K9.py
@@ -18,18 +18,18 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible_collections.community.ciscosmb.tests.unit.compat.mock import patch
-from ansible_collections.community.ciscosmb.plugins.modules import ciscosmb_facts
+from ansible_collections.community.ciscosmb.plugins.modules import facts
 from ansible_collections.community.ciscosmb.tests.unit.plugins.modules.utils import set_module_args
 from .ciscosmb_module import TestCiscoSMBModule, load_fixture
 
 
 class TestCiscoSMBFactsModule(TestCiscoSMBModule):
 
-    module = ciscosmb_facts
+    module = facts
 
     def setUp(self):
         super(TestCiscoSMBFactsModule, self).setUp()
-        self.mock_run_commands = patch('ansible_collections.community.ciscosmb.plugins.modules.ciscosmb_facts.run_commands')
+        self.mock_run_commands = patch('ansible_collections.community.ciscosmb.plugins.modules.facts.run_commands')
         self.run_commands = self.mock_run_commands.start()
 
     def tearDown(self):

--- a/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_facts-SG550X-24MP-K9.py
+++ b/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_facts-SG550X-24MP-K9.py
@@ -18,18 +18,18 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible_collections.community.ciscosmb.tests.unit.compat.mock import patch
-from ansible_collections.community.ciscosmb.plugins.modules import ciscosmb_facts
+from ansible_collections.community.ciscosmb.plugins.modules import facts
 from ansible_collections.community.ciscosmb.tests.unit.plugins.modules.utils import set_module_args
 from .ciscosmb_module import TestCiscoSMBModule, load_fixture
 
 
 class TestCiscoSMBFactsModule(TestCiscoSMBModule):
 
-    module = ciscosmb_facts
+    module = facts
 
     def setUp(self):
         super(TestCiscoSMBFactsModule, self).setUp()
-        self.mock_run_commands = patch('ansible_collections.community.ciscosmb.plugins.modules.ciscosmb_facts.run_commands')
+        self.mock_run_commands = patch('ansible_collections.community.ciscosmb.plugins.modules.facts.run_commands')
         self.run_commands = self.mock_run_commands.start()
 
     def tearDown(self):

--- a/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_facts-stackSG550X-48.py
+++ b/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_facts-stackSG550X-48.py
@@ -18,18 +18,18 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible_collections.community.ciscosmb.tests.unit.compat.mock import patch
-from ansible_collections.community.ciscosmb.plugins.modules import ciscosmb_facts
+from ansible_collections.community.ciscosmb.plugins.modules import facts
 from ansible_collections.community.ciscosmb.tests.unit.plugins.modules.utils import set_module_args
 from .ciscosmb_module import TestCiscoSMBModule, load_fixture
 
 
 class TestCiscoSMBFactsModule(TestCiscoSMBModule):
 
-    module = ciscosmb_facts
+    module = facts
 
     def setUp(self):
         super(TestCiscoSMBFactsModule, self).setUp()
-        self.mock_run_commands = patch('ansible_collections.community.ciscosmb.plugins.modules.ciscosmb_facts.run_commands')
+        self.mock_run_commands = patch('ansible_collections.community.ciscosmb.plugins.modules.facts.run_commands')
         self.run_commands = self.mock_run_commands.start()
 
     def tearDown(self):


### PR DESCRIPTION
##### SUMMARY
Rewrite community.ciscosmb.ciscosmb_facts to community.ciscosmb.facts
and Rewrite community.ciscosmb.ciscosmb_command to community.ciscosmb.command

Completes #29
