### PR TITLE
Pylint p39

### DIFF
--- a/.github/workflows/CI-AdP39.yml
+++ b/.github/workflows/CI-AdP39.yml
@@ -4,7 +4,7 @@
 # 3. If your collection depends on other collections ensure they are installed, see "Install collection dependencies"
 # If you need help please ask in the #ansible-community channel on Libera.Chat IRC (https://libera.chat/)
 
-name: CI
+name: CIAdP39
 on:
   workflow_dispatch:
 

--- a/plugins/cliconf/ciscosmb.py
+++ b/plugins/cliconf/ciscosmb.py
@@ -63,7 +63,7 @@ class Cliconf(CliconfBase):
         return device_info
 
     @enable_mode
-    def get_config(self, source='running', format=None, flags=None):
+    def get_config(self, source='running', flags=None, format=None):
         if source not in ("running", "startup"):
             raise ValueError(
                 "fetching configuration from %s is not supported" % source

--- a/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_command-CBS350-24P-4G.py
+++ b/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_command-CBS350-24P-4G.py
@@ -43,7 +43,7 @@ class TestCiscoSMBFactsModule(TestCiscoSMBModule):
             output = list()
 
             for command in commands:
-                filename = str(command).split(' | ')[0].replace(' ', '_')
+                filename = str(command).split(' | ', 1)[0].replace(' ', '_')
                 output.append(load_fixture('ciscosmb_command-CBS350-24P-4G-%s' % filename))
             return output
 

--- a/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_command-SG350-28-K9.py
+++ b/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_command-SG350-28-K9.py
@@ -43,7 +43,7 @@ class TestCiscoSMBFactsModule(TestCiscoSMBModule):
             output = list()
 
             for command in commands:
-                filename = str(command).split(' | ')[0].replace(' ', '_')
+                filename = str(command).split(' | ', 1)[0].replace(' ', '_')
                 output.append(load_fixture('ciscosmb_command-SG350-28-K9-%s' % filename))
             return output
 

--- a/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_command-SG500-52-K9.py
+++ b/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_command-SG500-52-K9.py
@@ -43,7 +43,7 @@ class TestCiscoSMBFactsModule(TestCiscoSMBModule):
             output = list()
 
             for command in commands:
-                filename = str(command).split(' | ')[0].replace(' ', '_')
+                filename = str(command).split(' | ', 1)[0].replace(' ', '_')
                 output.append(load_fixture('ciscosmb_command-SG500-52-K9-%s' % filename))
             return output
 

--- a/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_command-SG550X-24MP-K9.py
+++ b/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_command-SG550X-24MP-K9.py
@@ -43,7 +43,7 @@ class TestCiscoSMBFactsModule(TestCiscoSMBModule):
             output = list()
 
             for command in commands:
-                filename = str(command).split(' | ')[0].replace(' ', '_')
+                filename = str(command).split(' | ', 1)[0].replace(' ', '_')
                 output.append(load_fixture('ciscosmb_command-SG550X-24MP-K9-%s' % filename))
             return output
 

--- a/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_command-stackSG550X-48.py
+++ b/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_command-stackSG550X-48.py
@@ -43,7 +43,7 @@ class TestCiscoSMBFactsModule(TestCiscoSMBModule):
             output = list()
 
             for command in commands:
-                filename = str(command).split(' | ')[0].replace(' ', '_')
+                filename = str(command).split(' | ', 1)[0].replace(' ', '_')
                 output.append(load_fixture('ciscosmb_command-stackSG550X-48-%s' % filename))
             return output
 

--- a/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_facts-CBS350-24P-4G.py
+++ b/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_facts-CBS350-24P-4G.py
@@ -43,7 +43,7 @@ class TestCiscoSMBFactsModule(TestCiscoSMBModule):
             output = list()
 
             for command in commands:
-                filename = str(command).split(' | ')[0].replace(' ', '_')
+                filename = str(command).split(' | ', 1)[0].replace(' ', '_')
                 output.append(load_fixture('ciscosmb_facts-CBS350-24P-4G-%s' % filename))
             return output
 

--- a/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_facts-SG350-28-K9.py
+++ b/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_facts-SG350-28-K9.py
@@ -43,7 +43,7 @@ class TestCiscoSMBFactsModule(TestCiscoSMBModule):
             output = list()
 
             for command in commands:
-                filename = str(command).split(' | ')[0].replace(' ', '_')
+                filename = str(command).split(' | ', 1)[0].replace(' ', '_')
                 output.append(load_fixture('ciscosmb_facts-SG350-28-K9-%s' % filename))
             return output
 

--- a/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_facts-SG500-52-K9.py
+++ b/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_facts-SG500-52-K9.py
@@ -43,7 +43,7 @@ class TestCiscoSMBFactsModule(TestCiscoSMBModule):
             output = list()
 
             for command in commands:
-                filename = str(command).split(' | ')[0].replace(' ', '_')
+                filename = str(command).split(' | ', 1)[0].replace(' ', '_')
                 output.append(load_fixture('ciscosmb_facts-SG500-52-K9-%s' % filename))
             return output
 

--- a/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_facts-SG550X-24MP-K9.py
+++ b/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_facts-SG550X-24MP-K9.py
@@ -43,7 +43,7 @@ class TestCiscoSMBFactsModule(TestCiscoSMBModule):
             output = list()
 
             for command in commands:
-                filename = str(command).split(' | ')[0].replace(' ', '_')
+                filename = str(command).split(' | ', 1)[0].replace(' ', '_')
                 output.append(load_fixture('ciscosmb_facts-SG550X-24MP-K9-%s' % filename))
             return output
 

--- a/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_facts-SX550X-24F-K9.py
+++ b/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_facts-SX550X-24F-K9.py
@@ -43,7 +43,7 @@ class TestCiscoSMBFactsModule(TestCiscoSMBModule):
             output = list()
 
             for command in commands:
-                filename = str(command).split(' | ')[0].replace(' ', '_')
+                filename = str(command).split(' | ', 1)[0].replace(' ', '_')
                 output.append(load_fixture('ciscosmb_facts-SX550X-24F-K9-%s' % filename))
             return output
 

--- a/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_facts-stackSG550X-48.py
+++ b/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_facts-stackSG550X-48.py
@@ -43,7 +43,7 @@ class TestCiscoSMBFactsModule(TestCiscoSMBModule):
             output = list()
 
             for command in commands:
-                filename = str(command).split(' | ')[0].replace(' ', '_')
+                filename = str(command).split(' | ', 1)[0].replace(' ', '_')
                 output.append(load_fixture('ciscosmb_facts-stackSG550X-48-%s' % filename))
             return output
 


### PR DESCRIPTION
##### SUMMARY
CI started fail on Ansible Devel and Python 3.9, pylint is stricter there.

- cliconf get_config() definition had mixed parameters
- added maxsplit param to str.split()

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
- cliconf
- unit tests
