### PR TITLE
Fix link to issue tracker in galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -47,7 +47,7 @@ repository: https://github.com/ansible-collections/community.ciscosmb
 #homepage: http://example.com
 
 # The URL to the collection issue tracker
-issues: hhttps://github.com/ansible-collections/community.ciscosmb/issues
+issues: https://github.com/ansible-collections/community.ciscosmb/issues
 
 # A list of file glob-like patterns used to filter any files or directories that should not be included in the build
 # artifact. A pattern is matched from the relative path of the file or directory of the collection directory. This


### PR DESCRIPTION
##### SUMMARY
Currently the link to the issue tracker doesn't work on Galaxy due to a typo in galaxy.yml
Fix it for inclusion https://github.com/ansible-collections/ansible-inclusion/discussions/26#discussioncomment-1306296