### PR TITLE
Module command does not support check_mode

### DIFF
--- a/plugins/modules/command.py
+++ b/plugins/modules/command.py
@@ -62,8 +62,6 @@ options:
         trying the command again.
     default: 1
     type: int
-notes:
-  - Supports C(check_mode).
 '''
 
 EXAMPLES = """
@@ -142,7 +140,7 @@ def main():
     argument_spec.update(ciscosmb_argument_spec)
 
     module = AnsibleModule(argument_spec=argument_spec,
-                           supports_check_mode=True)
+                           supports_check_mode=False)
 
     result = {'changed': False}
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Module command does not support check_mode
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
community.ciscosmb.command
