### PR TITLE
C ichanges

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,6 @@ jobs:
           - stable-2.10
           - stable-2.11
           - stable-2.12
-          - stable-2.13
           - devel
     runs-on: ubuntu-latest
     steps:
@@ -93,7 +92,6 @@ jobs:
           - stable-2.10
           - stable-2.11
           - stable-2.12
-          - stable-2.13
           - devel
         python:
           - 2.6

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,6 +41,8 @@ jobs:
           - stable-2.9 # Only if your collection supports Ansible 2.9
           - stable-2.10
           - stable-2.11
+          - stable-2.12
+          - stable-2.13
           - devel
     runs-on: ubuntu-latest
     steps:
@@ -90,6 +92,8 @@ jobs:
           - stable-2.9 # Only if your collection supports Ansible 2.9
           - stable-2.10
           - stable-2.11
+          - stable-2.12
+          - stable-2.13
           - devel
         python:
           - 2.6
@@ -102,6 +106,8 @@ jobs:
           # no support of Python 3.9 in ansible-2.9
           - ansible: stable-2.9
             python: 3.9
+          - ansible: devel
+            python: 2.6
 
     steps:
       - name: Check out code

--- a/.github/workflows/FastCI.yml
+++ b/.github/workflows/FastCI.yml
@@ -37,8 +37,7 @@ jobs:
           #- stable-2.9 # Only if your collection supports Ansible 2.9
           #- stable-2.10
           #- stable-2.11
-          #- stable-2.12
-          - stable-2.13
+          - stable-2.12
           #- devel
     runs-on: ubuntu-latest
     steps:
@@ -88,8 +87,7 @@ jobs:
           #- stable-2.9 # Only if your collection supports Ansible 2.9
           #- stable-2.10
           #- stable-2.11
-          #- stable-2.12
-          - stable-2.13
+          - stable-2.12
           #- devel
         python:
           #- 2.6

--- a/.github/workflows/FastCI.yml
+++ b/.github/workflows/FastCI.yml
@@ -35,8 +35,10 @@ jobs:
           # It's important that Sanity is tested against all stable-X.Y branches
           # Testing against `devel` may fail as new tests are added.
           #- stable-2.9 # Only if your collection supports Ansible 2.9
-          - stable-2.10
+          #- stable-2.10
           #- stable-2.11
+          #- stable-2.12
+          - stable-2.13
           #- devel
     runs-on: ubuntu-latest
     steps:
@@ -84,8 +86,10 @@ jobs:
       matrix:
         ansible:
           #- stable-2.9 # Only if your collection supports Ansible 2.9
-          - stable-2.10
+          #- stable-2.10
           #- stable-2.11
+          #- stable-2.12
+          - stable-2.13
           #- devel
         python:
           #- 2.6


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add ansible-2.12 to CI tests
anisble-devel does not support Py2.6

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
