### PR TITLE
Remove erroneous priv. test - it falsely skip 'enable' for priv. 15

### DIFF
--- a/plugins/terminal/ciscosmb.py
+++ b/plugins/terminal/ciscosmb.py
@@ -80,9 +80,6 @@ class TerminalModule(TerminalBase):
             )
 
     def on_become(self, passwd=None):
-        if self._get_prompt().endswith(b"#"):
-            return
-
         cmd = {u"command": u"enable"}
         if passwd:
             # Note: python-3.5 cannot combine u"" and r"" together.  Thus make


### PR DESCRIPTION
##### SUMMARY
function on_become() tests current user privilege on prompt basis. It is false on priv. level 7 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
terminal module

##### ADDITIONAL INFORMATION
Thanks to @ckhordiasma for investigating.