### PR TITLE
Revert breaking changes

### DIFF
--- a/changelogs/fragments/.keep
+++ b/changelogs/fragments/.keep
@@ -1,4 +1,4 @@
-# fragment.xml
+# fragment.yml
 release_summary: |
     Release Date: 2019-10-31
     `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`

--- a/changelogs/fragments/75-versioning_violation.yml
+++ b/changelogs/fragments/75-versioning_violation.yml
@@ -1,0 +1,12 @@
+release_summary: |
+  Primarily revert release. Previous release (1.0.8) fixed typo in attribute name, but it was breaking change.
+  This release brought the typo back (bandwith) and just added the new attribute with correct name "bandwidth" as a copy of the mistypped attribute.
+
+  Attribude "bandwith" will be removed in next minor release.
+
+bugfixes:
+  - typo in test script
+  - typo in changelog fragment template
+minor_changes:
+  - added additional attribute - add interface 'bandwidth' attribute
+  - reverted attribute change - keep interface 'bandwith' attribute

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: community
 name: ciscosmb 
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.8
+version: 1.0.9
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/modules/facts.py
+++ b/plugins/modules/facts.py
@@ -424,8 +424,10 @@ class Interfaces(FactsBase):
 
             if i[6] == "Up":
                 interface["bandwidth"] = int(i[3]) * 1000  # to get speed in kb
+                interface["bandwith"] = interface["bandwidth"]
             else:
                 interface["bandwidth"] = None
+                interface["bandwith"] = interface["bandwidth"]
 
             for key in interface:
                 if interface[key] == "--":
@@ -450,8 +452,10 @@ class Interfaces(FactsBase):
 
             if i[6] == "Up":
                 interface["bandwidth"] = int(i[3]) * 1000  # to get speed in kb
+                interface["bandwith"] = interface["bandwidth"]
             else:
                 interface["bandwidth"] = None
+                interface["bandwith"] = interface["bandwidth"]
 
             for key in interface:
                 if interface[key] == "--":
@@ -625,6 +629,7 @@ class Interfaces(FactsBase):
             self.facts["interfaces"][interface]["description"] = None
             self.facts["interfaces"][interface]["state"] = "up"
             self.facts["interfaces"][interface]["bandwidth"] = None
+            self.facts["interfaces"][interface]["bandwith"] = None
             self.facts["interfaces"][interface]["duplex"] = None
             self.facts["interfaces"][interface]["negotiation"] = None
             self.facts["interfaces"][interface]["control"] = None

--- a/tests/unit/compat/mock.py
+++ b/tests/unit/compat/mock.py
@@ -64,7 +64,7 @@ if sys.version_info >= (3,) and sys.version_info < (3, 4, 4):
             # newline that our naive format() added
             data_as_list[-1] = data_as_list[-1][:-1]
 
-        yield from data_as_list
+        yield data_as_list
 
     def mock_open(mock=None, read_data=''):
         """
@@ -92,7 +92,7 @@ if sys.version_info >= (3,) and sys.version_info < (3, 4, 4):
             if handle.readline.return_value is not None:
                 while True:
                     yield handle.readline.return_value
-            yield from _data
+            yield _data
 
         global file_spec
         if file_spec is None:

--- a/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_facts-SG500-52-K9.py
+++ b/tests/unit/plugins/modules/ciscosmb/test_ciscosmb_facts-SG500-52-K9.py
@@ -116,6 +116,13 @@ class TestCiscoSMBFactsModule(TestCiscoSMBModule):
             len(result['ansible_facts']['ansible_net_neighbors']), 9
         )
 
+        interfaces = result['ansible_facts']['ansible_net_interfaces']
+        ge42 = interfaces['GigabitEthernet1/42']
+
+        self.assertEqual(ge42['bandwidth'], 1000000)
+
+        self.assertEqual(ge42['bandwidth'], ge42['bandwith'])
+
 #     def test_ciscosmb_facts_routing(self):
 #         set_module_args(dict(gather_subset='routing'))
 #         result = self.execute_module()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes Collection Requirements Violation - Semantic Versioning #75

Primarily revert release. Previous release (1.0.8) fixed typo in attribute name, but it was breaking change.
  This release brought the typo back (bandwith) and just added the new attribute with correct name "bandwidth" as a copy of the mistypped attribute.

  Attribude "bandwith" will be removed in next minor release.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
