### PR TITLE
Problems with community.ciscosmb.facts and gather_subset

### DIFF
--- a/plugins/modules/facts.py
+++ b/plugins/modules/facts.py
@@ -270,8 +270,9 @@ class Default(FactsBase):
                 line,
             )
 
-            modul = match.groupdict()
-            modules[modul["name"]] = modul
+            if match:
+                modul = match.groupdict()
+                modules[modul["name"]] = modul
 
         if modules:
             return modules

--- a/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_command-C1300-8FP-2G-show_version
+++ b/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_command-C1300-8FP-2G-show_version
@@ -1,0 +1,10 @@
+Active-image: flash://system/images/image_c1300_4.1.6.54_official_key.bin
+  Version: 4.1.6.54
+  MD5 Digest: 9ebbfe128965ba857b81fb75292c84ec
+  Date: 18-Feb-2025
+  Time: 07:02:12
+Inactive-image: flash://system/images/image_4.1.3.36.bin
+  Version: 4.1.3.36
+  MD5 Digest: 90803a985c9110cef9aa4d576206b629
+  Date: 19-May-2024
+  Time: 08:17:26

--- a/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_facts-C1300-8FP-2G-dir
+++ b/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_facts-C1300-8FP-2G-dir
@@ -1,0 +1,14 @@
+Permissions
+    d-directory
+    r-readable
+    w-writable
+    x-executable
+165100K of 305484K are free
+Directory of flash://
+
+Permission File Size   Last Modified        File Name
+---------- --------- -------------------- --------------------------------------
+   dr--      1608    18-Feb-2025 06:34:16 system
+
+
+

--- a/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_facts-C1300-8FP-2G-show_cpu_utilization
+++ b/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_facts-C1300-8FP-2G-show_cpu_utilization
@@ -1,0 +1,5 @@
+CPU utilization service is on.
+
+CPU utilization
+---------------
+five seconds: 1%; one minute: 0%; five minutes: 1%

--- a/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_facts-C1300-8FP-2G-show_interfaces_configuration
+++ b/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_facts-C1300-8FP-2G-show_interfaces_configuration
@@ -1,0 +1,25 @@
+                                                Flow    Admin     Back   Mdix
+Port      Type         Duplex  Speed  Neg      control  State   Pressure Mode
+--------- ------------ ------  -----  -------- -------  -----   -------- ----
+gi1       1G-Copper    Full    1000   Enabled  Off      Up      Disabled Auto
+gi2       1G-Copper    Full    1000   Enabled  Off      Up      Disabled Auto
+gi3       1G-Copper    Full    1000   Enabled  Off      Up      Disabled Auto
+gi4       1G-Copper    Full    1000   Enabled  Off      Up      Disabled Auto
+gi5       1G-Copper    Full    1000   Enabled  Off      Up      Disabled Auto
+gi6       1G-Copper    Full    1000   Enabled  Off      Up      Disabled Auto
+gi7       1G-Copper    Full    1000   Enabled  Off      Up      Disabled Auto
+gi8       1G-Copper    Full    1000   Enabled  Off      Up      Disabled Auto
+gi9       1G-Combo-C   Full    1000   Enabled  Off      Up      Disabled Auto
+gi10      1G-Combo-C   Full    1000   Enabled  Off      Up      Disabled Auto
+
+                                  Flow    Admin
+Ch       Type    Speed  Neg      control  State
+-------- ------- -----  -------- -------  -----
+Po1         --     --   Enabled  Off      Up
+Po2         --     --   Enabled  Off      Up
+Po3         --     --   Enabled  Off      Up
+Po4         --     --   Enabled  Off      Up
+Po5         --     --   Enabled  Off      Up
+Po6         --     --   Enabled  Off      Up
+Po7         --     --   Enabled  Off      Up
+Po8         --     --   Enabled  Off      Up

--- a/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_facts-C1300-8FP-2G-show_interfaces_description
+++ b/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_facts-C1300-8FP-2G-show_interfaces_description
@@ -1,0 +1,27 @@
+Port      Description
+-------   -----------
+gi1
+gi2
+gi3
+gi4
+gi5
+gi6
+gi7
+gi8
+gi9
+gi10
+
+Ch        Description
+-------   -----------
+Po1
+Po2
+Po3
+Po4
+Po5
+Po6
+Po7
+Po8
+
+Bluetooth      Description
+------------   -----------
+bluetooth 0

--- a/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_facts-C1300-8FP-2G-show_interfaces_status
+++ b/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_facts-C1300-8FP-2G-show_interfaces_status
@@ -1,0 +1,25 @@
+                                              Flow Link          Back   Mdix
+Port      Type         Duplex  Speed Neg      ctrl State       Pressure Mode
+--------- ------------ ------  ----- -------- ---- ----------- -------- -------
+gi1       1G-Copper    Full    1000  Enabled  Off  Up          Disabled On
+gi2       1G-Copper    Full    100   Enabled  Off  Up          Disabled On
+gi3       1G-Copper    Full    1000  Enabled  Off  Up          Disabled On
+gi4       1G-Copper    Full    1000  Enabled  Off  Up          Disabled On
+gi5       1G-Copper      --      --     --     --  Down           --     --
+gi6       1G-Copper      --      --     --     --  Down           --     --
+gi7       1G-Copper      --      --     --     --  Down           --     --
+gi8       1G-Copper      --      --     --     --  Down           --     --
+gi9       1G-Combo-C     --      --     --     --  Down           --     --
+gi10      1G-Combo-C   Full    100   Enabled  Off  Up          Disabled Off
+
+                                          Flow    Link
+Ch       Type    Duplex  Speed  Neg      control  State
+-------- ------- ------  -----  -------- -------  -----------
+Po1         --     --      --      --       --    Not Present
+Po2         --     --      --      --       --    Not Present
+Po3         --     --      --      --       --    Not Present
+Po4         --     --      --      --       --    Not Present
+Po5         --     --      --      --       --    Not Present
+Po6         --     --      --      --       --    Not Present
+Po7         --     --      --      --       --    Not Present
+Po8         --     --      --      --       --    Not Present

--- a/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_facts-C1300-8FP-2G-show_inventory
+++ b/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_facts-C1300-8FP-2G-show_inventory
@@ -1,0 +1,3 @@
+
+NAME: "1"  DESCR: "Catalyst 1300 Series Managed Switch, 8-port GE, Full PoE, 2x1G Combo (C1300-8FP-2G)"
+PID: C1300-8FP-2G  VID:  V02  SN: FOC2222291D

--- a/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_facts-C1300-8FP-2G-show_ip_interface
+++ b/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_facts-C1300-8FP-2G-show_ip_interface
@@ -1,0 +1,10 @@
+
+
+IP Address         I/F       I/F Status Type    Directed  Prec Redirect Status
+                             admin/oper         Broadcast
+------------------ --------- ---------- ------- --------- ---- -------- ------
+0.0.0.0/32         vlan 1    UP/DOWN    DHCP    disable   No   enable   Not
+                                                                        receiv
+                                                                        ed
+10.10.10.2/24      vlan 999  UP/UP      Static  disable   No   enable   Valid
+

--- a/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_facts-C1300-8FP-2G-show_ip_route
+++ b/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_facts-C1300-8FP-2G-show_ip_route
@@ -1,0 +1,9 @@
+Maximum Parallel Paths: 1 (1 after reset)
+IP Forwarding: enabled
+Codes: > - best, C - connected, S - static
+       R - RIP
+
+
+S   0.0.0.0/0 [1/4] via 10.10.10.1, 459:17:17, vlan 999
+C   10.10.10.0/24 is directly connected, vlan 999
+

--- a/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_facts-C1300-8FP-2G-show_ipv6_interface_brief
+++ b/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_facts-C1300-8FP-2G-show_ipv6_interface_brief
@@ -1,0 +1,6 @@
+
+Interface    Interface IPv6          Link Local            MLD      Number of
+           State     State        IPv6 Address           Version Global Addresses
+---------- --------- --------- ------------------------- ------- ----------------
+  vlan 1    up/down   enabled  fe80::960d:41ff:ffcf:1e71    2           0
+

--- a/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_facts-C1300-8FP-2G-show_ports_jumbo-frame
+++ b/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_facts-C1300-8FP-2G-show_ports_jumbo-frame
@@ -1,0 +1,3 @@
+
+ Jumbo frames are disabled
+ Jumbo frames will be disabled after reset

--- a/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_facts-C1300-8FP-2G-show_system
+++ b/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_facts-C1300-8FP-2G-show_system
@@ -1,0 +1,17 @@
+System Description:                       Catalyst 1300 Series Managed Switch, 8-port GE, Full PoE, 2x1G Combo (C1300-8FP-2G)
+System Up Time (days,hour:min:sec):       43,23:42:25
+System Contact:
+System Name:                              hostname
+System Location:
+System MAC Address:                       94:0d:4b:0A:0A:0A
+System Object ID:                         1.3.6.1.4.1.9.1.3228
+
+Unit Type
+---- ----------------------
+ 1        C1300-8FP-2G
+
+
+Unit Temperature (Celsius) Status
+---- --------------------- ----------
+ 1            45               OK
+

--- a/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_facts-C1300-8FP-2G-show_version
+++ b/tests/unit/plugins/modules/ciscosmb/fixtures/ciscosmb_facts-C1300-8FP-2G-show_version
@@ -1,0 +1,10 @@
+Active-image: flash://system/images/image_c1300_4.1.6.54_official_key.bin
+  Version: 4.1.6.54
+  MD5 Digest: 9ebbfe128965ba857b81fb75292c84ec
+  Date: 18-Feb-2025
+  Time: 07:02:12
+Inactive-image: flash://system/images/image_4.1.3.36.bin
+  Version: 4.1.3.36
+  MD5 Digest: 90803a985c9110cef9aa4d576206b629
+  Date: 19-May-2024
+  Time: 08:17:26


### PR DESCRIPTION
Fixed bug where there are multiple lines in `lines` and no regexp match in the second line. Which generates an error when the `match` is None

##### SUMMARY
When I tried to run the facts function on a new Catalyst C1300 I got the following error on line 275 in plugins/modules/facts.py
`AttributeError: 'NoneType' object has no attribute 'groupdict'`

After some debugging, I noticed that the variable `lines` had the following value:
`['NAME: \"1\"  DESCR: \"Catalyst 1300 Series Managed Switch, 8-port GE, Full PoE, 2x1G Combo (C1300-8FP-2G)\"    PID: C1300-8FP-2G  VID:  V02  SN: PVR78211ETV  ', 'switchce947c#']`

To solve this I added an `if` to make it only add data to `modules` if the regex found something.

##### ISSUE TYPE
- Bugfix Pull Request